### PR TITLE
Include revenue in the GET /api/developers endpoint

### DIFF
--- a/src/domain/developers/services/developers.service.ts
+++ b/src/domain/developers/services/developers.service.ts
@@ -7,18 +7,7 @@ export class DevelopersService {
 
 	constructor(
 		@inject('DevelopersRepository') private developersRepository: DevelopersRepository,
-	) { }
-
-	private async getContractsSafe(): Promise<any[]> {
-		try {
-			const maybeFn: any = (this.developersRepository as any).getContracts
-			if (typeof maybeFn !== 'function') return []
-			const result = await maybeFn.call(this.developersRepository)
-			return Array.isArray(result) ? result : []
-		} catch (_e) {
-			return []
-		}
-	}
+	) {}
 
 	async getDevelopers(options?: { includeRevenue?: boolean }): Promise<IDeveloper[]> {
 		const includeRevenue = !!options?.includeRevenue
@@ -29,41 +18,27 @@ export class DevelopersService {
 
 		const [developers, contracts] = await Promise.all([
 			this.developersRepository.getDevelopers(),
-			this.getContractsSafe()
+			this.developersRepository.getContracts(),
 		])
 
 		const completedByDeveloper = new Map<string, number>()
-		for (const c of contracts) {
-			if (c.status === 'completed') {
+		for (const contract of contracts) {
+			if (contract.status === 'completed') {
 				completedByDeveloper.set(
-					c.developerId,
-					(completedByDeveloper.get(c.developerId) || 0) + (c.amount || 0)
+					contract.developerId,
+					(completedByDeveloper.get(contract.developerId) || 0) + (contract.amount || 0)
 				)
 			}
 		}
 
-		return developers.map(d => ({
-			...d,
-			revenue: completedByDeveloper.get(d.id) || 0,
+		return developers.map(developer => ({
+			...developer,
+			revenue: completedByDeveloper.get(developer.id) || 0,
 		}))
 	}
 
 	async getDeveloperById(id: string) {
-		const [developer, contracts] = await Promise.all([
-			this.developersRepository.getDeveloperById(id),
-			this.getContractsSafe()
-		])
-
-		if (!developer) return developer
-
-		let revenue = 0
-		for (const c of contracts) {
-			if (c.developerId === id && c.status === 'completed') {
-				revenue += c.amount || 0
-			}
-		}
-
-		return { ...developer, revenue }
+		return this.developersRepository.getDeveloperById(id)
 	}
 
 }

--- a/src/domain/developers/services/developers.service.ts
+++ b/src/domain/developers/services/developers.service.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'inversify';
 import { DevelopersRepository } from '../repositories/developers.repository';
 import { IDeveloper } from '../types'
+import { computeCompletedRevenueByDeveloper, addRevenueToDevelopers } from '../utils'
 
 @injectable()
 export class DevelopersService {
@@ -21,20 +22,8 @@ export class DevelopersService {
 			this.developersRepository.getContracts(),
 		])
 
-		const completedByDeveloper = new Map<string, number>()
-		for (const contract of contracts) {
-			if (contract.status === 'completed') {
-				completedByDeveloper.set(
-					contract.developerId,
-					(completedByDeveloper.get(contract.developerId) || 0) + (contract.amount || 0)
-				)
-			}
-		}
-
-		return developers.map(developer => ({
-			...developer,
-			revenue: completedByDeveloper.get(developer.id) || 0,
-		}))
+		const revenueByDeveloper = computeCompletedRevenueByDeveloper(contracts)
+		return addRevenueToDevelopers(developers, revenueByDeveloper)
 	}
 
 	async getDeveloperById(id: string) {

--- a/src/domain/developers/services/developers.service.ts
+++ b/src/domain/developers/services/developers.service.ts
@@ -7,14 +7,63 @@ export class DevelopersService {
 
 	constructor(
 		@inject('DevelopersRepository') private developersRepository: DevelopersRepository,
-	) {}
+	) { }
 
-	async getDevelopers(): Promise<IDeveloper[]>{
-		return this.developersRepository.getDevelopers()
+	private async getContractsSafe(): Promise<any[]> {
+		try {
+			const maybeFn: any = (this.developersRepository as any).getContracts
+			if (typeof maybeFn !== 'function') return []
+			const result = await maybeFn.call(this.developersRepository)
+			return Array.isArray(result) ? result : []
+		} catch (_e) {
+			return []
+		}
 	}
 
-	async getDeveloperById(id: string){
-		return this.developersRepository.getDeveloperById(id)
+	async getDevelopers(options?: { includeRevenue?: boolean }): Promise<IDeveloper[]> {
+		const includeRevenue = !!options?.includeRevenue
+
+		if (!includeRevenue) {
+			return this.developersRepository.getDevelopers()
+		}
+
+		const [developers, contracts] = await Promise.all([
+			this.developersRepository.getDevelopers(),
+			this.getContractsSafe()
+		])
+
+		const completedByDeveloper = new Map<string, number>()
+		for (const c of contracts) {
+			if (c.status === 'completed') {
+				completedByDeveloper.set(
+					c.developerId,
+					(completedByDeveloper.get(c.developerId) || 0) + (c.amount || 0)
+				)
+			}
+		}
+
+		return developers.map(d => ({
+			...d,
+			revenue: completedByDeveloper.get(d.id) || 0,
+		}))
+	}
+
+	async getDeveloperById(id: string) {
+		const [developer, contracts] = await Promise.all([
+			this.developersRepository.getDeveloperById(id),
+			this.getContractsSafe()
+		])
+
+		if (!developer) return developer
+
+		let revenue = 0
+		for (const c of contracts) {
+			if (c.developerId === id && c.status === 'completed') {
+				revenue += c.amount || 0
+			}
+		}
+
+		return { ...developer, revenue }
 	}
 
 }

--- a/src/domain/developers/types.ts
+++ b/src/domain/developers/types.ts
@@ -1,11 +1,14 @@
 export interface IDeveloper {
-
 	id: string
-
 	firstName?: string
 	lastName?: string
-
 	email: string
-
 	revenue?: number
+}
+
+export interface IContract {
+	id: string
+	developerId: string
+	status?: string
+	amount?: number
 }

--- a/src/domain/developers/types.ts
+++ b/src/domain/developers/types.ts
@@ -7,7 +7,7 @@ export interface IDeveloper {
 }
 
 export interface IContract {
-	id: string
+	id: number | string
 	developerId: string
 	status?: string
 	amount?: number

--- a/src/domain/developers/types.ts
+++ b/src/domain/developers/types.ts
@@ -8,5 +8,4 @@ export interface IDeveloper {
 	email: string
 
 	revenue?: number
-
 }

--- a/src/domain/developers/types.ts
+++ b/src/domain/developers/types.ts
@@ -7,4 +7,7 @@ export interface IDeveloper {
 
 	email: string
 
+	// optional computed field, not persisted
+	revenue?: number
+
 }

--- a/src/domain/developers/types.ts
+++ b/src/domain/developers/types.ts
@@ -7,7 +7,6 @@ export interface IDeveloper {
 
 	email: string
 
-	// optional computed field, not persisted
 	revenue?: number
 
 }

--- a/src/domain/developers/utils.ts
+++ b/src/domain/developers/utils.ts
@@ -1,0 +1,26 @@
+import { IDeveloper, IContract } from './types'
+
+export function computeCompletedRevenueByDeveloper(contracts: IContract[]): Map<string, number> {
+  const completedByDeveloper = new Map<string, number>()
+  for (const contract of contracts || []) {
+    if (contract && contract.status === 'completed') {
+      completedByDeveloper.set(
+        contract.developerId,
+        (completedByDeveloper.get(contract.developerId) || 0) + (contract.amount || 0)
+      )
+    }
+  }
+  return completedByDeveloper
+}
+
+export function addRevenueToDevelopers(
+  developers: IDeveloper[],
+  revenueByDeveloper: Map<string, number>
+): IDeveloper[] {
+  return (developers || []).map(developer => ({
+    ...developer,
+    revenue: revenueByDeveloper.get(developer.id) || 0,
+  }))
+}
+
+

--- a/src/rest/controllers/developers.controller.ts
+++ b/src/rest/controllers/developers.controller.ts
@@ -2,7 +2,7 @@ import {
 	interfaces,
 	controller,
 	BaseHttpController,
-	httpGet, requestParam
+	httpGet, requestParam, queryParam
 } from 'inversify-express-utils';
 import { ApiOperationGet, ApiPath } from 'swagger-express-ts';
 import {
@@ -18,12 +18,13 @@ export class DevelopersController extends BaseHttpController implements interfac
 
 	constructor(
 		@inject('DevelopersService') private developersService: DevelopersService,
-	){ super() }
+	) { super() }
 
 	@httpGet('/')
 	@ApiOperationGet(getDevelopers)
-	public async getDevelopers(): Promise<DeveloperDto[]> {
-		return this.developersService.getDevelopers()
+	public async getDevelopers(@queryParam('include') include?: string): Promise<DeveloperDto[]> {
+		const includeRevenue = include === 'revenue'
+		return this.developersService.getDevelopers({ includeRevenue })
 	}
 
 	@httpGet('/:id')

--- a/src/rest/controllers/developers.controller.ts
+++ b/src/rest/controllers/developers.controller.ts
@@ -18,13 +18,12 @@ export class DevelopersController extends BaseHttpController implements interfac
 
 	constructor(
 		@inject('DevelopersService') private developersService: DevelopersService,
-	) { super() }
+	){ super() }
 
 	@httpGet('/')
 	@ApiOperationGet(getDevelopers)
 	public async getDevelopers(@queryParam('include') include?: string): Promise<DeveloperDto[]> {
-		const includeRevenue = include === 'revenue'
-		return this.developersService.getDevelopers({ includeRevenue })
+		return this.developersService.getDevelopers({ includeRevenue: include === 'revenue' })
 	}
 
 	@httpGet('/:id')

--- a/src/rest/dto/developers.responses.dto.ts
+++ b/src/rest/dto/developers.responses.dto.ts
@@ -16,5 +16,7 @@ export class DeveloperDto implements IDeveloper {
 	@ApiModelProperty()
 	email: string
 
+	@ApiModelProperty({ description: 'Total revenue from completed contracts', required: false })
+	revenue?: number
 
 }

--- a/src/rest/swagger/developers.swagger.docs.ts
+++ b/src/rest/swagger/developers.swagger.docs.ts
@@ -27,7 +27,7 @@ export const getDevelopers: IApiOperationArgsBase = {
 }
 
 export const getDeveloperById: IApiOperationArgsBase = {
-	summary: "Get developer by id (includes computed revenue from completed contracts)",
+	summary: "Get developer by id (used by contracts management dashboard)",
 	path: '/{id}',
 	parameters: {
 		path: { id: { required: true, name: 'id', description: 'Developer id' } },

--- a/src/rest/swagger/developers.swagger.docs.ts
+++ b/src/rest/swagger/developers.swagger.docs.ts
@@ -7,9 +7,16 @@ export const path: IApiPathArgs = {
 }
 
 export const getDevelopers: IApiOperationArgsBase = {
-	summary: "Get full list of developers (used by developers management dashboard and contracts management dashboard)",
+	summary: "Get full list of developers (optionally include revenue from completed contracts)",
 	path: '/',
 	parameters: {
+		query: {
+			include: {
+				required: false,
+				name: 'include',
+				description: "Optional include fields. Supported: 'revenue'",
+			}
+		}
 	},
 	responses: {
 		200: {
@@ -20,7 +27,7 @@ export const getDevelopers: IApiOperationArgsBase = {
 }
 
 export const getDeveloperById: IApiOperationArgsBase = {
-	summary: "Get developer by id (used by contracts management dashboard)",
+	summary: "Get developer by id (includes computed revenue from completed contracts)",
 	path: '/{id}',
 	parameters: {
 		path: { id: { required: true, name: 'id', description: 'Developer id' } },

--- a/test/developers.test.ts
+++ b/test/developers.test.ts
@@ -17,7 +17,6 @@ describe('Developers API tests examples', () => {
 			expect(developer).toHaveProperty('firstName')
 			expect(developer).toHaveProperty('lastName')
 			expect(developer).toHaveProperty('email')
-			// revenue should not be present unless include=revenue is passed
 			expect(developer).not.toHaveProperty('revenue')
 		}
 
@@ -25,30 +24,44 @@ describe('Developers API tests examples', () => {
 
 	it('should include revenue when include=revenue is specified', async () => {
 
-		const result = await request.get(`/api/developers?include=revenue`)
+		const req = await createRequestWithContainerOverrides({
+			'DevelopersRepository': {
+				toConstantValue: {
+					getDevelopers: async () => [{
+						"id": "65de346c255f31cb84bd105c",
+						"email": "Oran_Schroeder97@yahoo.com",
+						"firstName": "Oran",
+						"lastName": "Schroeder"
+					},
+					{
+						"id": "65de346a255f31cb84bd0e01",
+						"email": "Katheryn82@hotmail.com",
+						"firstName": "Katheryn",
+						"lastName": "Hammes"
+					},],
+					getContracts: async () => [
+						{ id: 5, developerId: '65de346a255f31cb84bd0e01', status: 'completed', amount: 6000 },
+						{ id: 6, developerId: '65de346a255f31cb84bd0e01', status: 'completed', amount: 5000 },
+					],
+				} as Partial<DevelopersRepository>
+			}
+		})
+
+		const result = await req.get(`/api/developers/?include=revenue`)
 
 		expect(result.status).toBe(200)
 		expect(Array.isArray(result.body)).toBe(true)
 
-		// pick some known developers from seed data to validate revenue calculation
 		const developers = result.body
 		const byId = (id: string) => developers.find((d: any) => d.id === id)
 
-		// 65de346c255f31cb84bd10e9 has one completed contract: 12000
-		const devWith12000 = byId('65de346c255f31cb84bd10e9')
-		expect(devWith12000).toBeTruthy()
-		expect(devWith12000).toHaveProperty('revenue', 12000)
+		const dev1 = byId('65de346a255f31cb84bd0e01')
+		expect(dev1).toBeTruthy()
+		expect(dev1).toHaveProperty('revenue', 11000)
 
-		// 65de346a255f31cb84bd0e01 has two completed: 6000 + 5000 = 11000
-		const devWith11000 = byId('65de346a255f31cb84bd0e01')
-		expect(devWith11000).toBeTruthy()
-		expect(devWith11000).toHaveProperty('revenue', 11000)
-
-		// a developer with no completed contracts should have revenue 0
-		const devNoCompleted = byId('65de3467255f31cb84bd071d') // only pending/ongoing
-		expect(devNoCompleted).toBeTruthy()
-		expect(devNoCompleted).toHaveProperty('revenue', 0)
-
+		const dev2 = byId('65de346c255f31cb84bd105c')
+		expect(dev2).toBeTruthy()
+		expect(dev2).toHaveProperty('revenue', 0)
 	})
 
 	it('should ignore unknown include values and not include revenue', async () => {

--- a/test/developers.test.ts
+++ b/test/developers.test.ts
@@ -12,11 +12,52 @@ describe('Developers API tests examples', () => {
 		expect(result.status).toBe(200)
 		expect(result.body?.length).toBeGreaterThan(0)
 
-		for( const developer of result.body ){
+		for (const developer of result.body) {
 			expect(developer).toHaveProperty('id')
 			expect(developer).toHaveProperty('firstName')
 			expect(developer).toHaveProperty('lastName')
 			expect(developer).toHaveProperty('email')
+			// revenue should not be present unless include=revenue is passed
+			expect(developer).not.toHaveProperty('revenue')
+		}
+
+	})
+
+	it('should include revenue when include=revenue is specified', async () => {
+
+		const result = await request.get(`/api/developers?include=revenue`)
+
+		expect(result.status).toBe(200)
+		expect(Array.isArray(result.body)).toBe(true)
+
+		// pick some known developers from seed data to validate revenue calculation
+		const developers = result.body
+		const byId = (id: string) => developers.find((d: any) => d.id === id)
+
+		// 65de346c255f31cb84bd10e9 has one completed contract: 12000
+		const devWith12000 = byId('65de346c255f31cb84bd10e9')
+		expect(devWith12000).toBeTruthy()
+		expect(devWith12000).toHaveProperty('revenue', 12000)
+
+		// 65de346a255f31cb84bd0e01 has two completed: 6000 + 5000 = 11000
+		const devWith11000 = byId('65de346a255f31cb84bd0e01')
+		expect(devWith11000).toBeTruthy()
+		expect(devWith11000).toHaveProperty('revenue', 11000)
+
+		// a developer with no completed contracts should have revenue 0
+		const devNoCompleted = byId('65de3467255f31cb84bd071d') // only pending/ongoing
+		expect(devNoCompleted).toBeTruthy()
+		expect(devNoCompleted).toHaveProperty('revenue', 0)
+
+	})
+
+	it('should ignore unknown include values and not include revenue', async () => {
+
+		const result = await request.get(`/api/developers?include=something_else`)
+
+		expect(result.status).toBe(200)
+		for (const developer of result.body) {
+			expect(developer).not.toHaveProperty('revenue')
 		}
 
 	})

--- a/test/developers.test.ts
+++ b/test/developers.test.ts
@@ -22,59 +22,6 @@ describe('Developers API tests examples', () => {
 
 	})
 
-	it('should include revenue when include=revenue is specified', async () => {
-
-		const req = await createRequestWithContainerOverrides({
-			'DevelopersRepository': {
-				toConstantValue: {
-					getDevelopers: async () => [{
-						"id": "65de346c255f31cb84bd105c",
-						"email": "Oran_Schroeder97@yahoo.com",
-						"firstName": "Oran",
-						"lastName": "Schroeder"
-					},
-					{
-						"id": "65de346a255f31cb84bd0e01",
-						"email": "Katheryn82@hotmail.com",
-						"firstName": "Katheryn",
-						"lastName": "Hammes"
-					},],
-					getContracts: async () => [
-						{ id: 5, developerId: '65de346a255f31cb84bd0e01', status: 'completed', amount: 6000 },
-						{ id: 6, developerId: '65de346a255f31cb84bd0e01', status: 'completed', amount: 5000 },
-					],
-				} as Partial<DevelopersRepository>
-			}
-		})
-
-		const result = await req.get(`/api/developers/?include=revenue`)
-
-		expect(result.status).toBe(200)
-		expect(Array.isArray(result.body)).toBe(true)
-
-		const developers = result.body
-		const byId = (id: string) => developers.find((d: any) => d.id === id)
-
-		const dev1 = byId('65de346a255f31cb84bd0e01')
-		expect(dev1).toBeTruthy()
-		expect(dev1).toHaveProperty('revenue', 11000)
-
-		const dev2 = byId('65de346c255f31cb84bd105c')
-		expect(dev2).toBeTruthy()
-		expect(dev2).toHaveProperty('revenue', 0)
-	})
-
-	it('should ignore unknown include values and not include revenue', async () => {
-
-		const result = await request.get(`/api/developers?include=something_else`)
-
-		expect(result.status).toBe(200)
-		for (const developer of result.body) {
-			expect(developer).not.toHaveProperty('revenue')
-		}
-
-	})
-
 	it('should BAT get developer by id (mocked repository used)', async () => {
 
 		const req = await createRequestWithContainerOverrides({
@@ -102,4 +49,69 @@ describe('Developers API tests examples', () => {
 
 	})
 
+	describe('Revenue data', () => {
+		let req: any
+
+		beforeEach(async () => {
+			req = await createRequestWithContainerOverrides({
+				'DevelopersRepository': {
+					toConstantValue: {
+						getDevelopers: async () => [{
+							"id": "65de346c255f31cb84bd105c",
+							"email": "Oran_Schroeder97@yahoo.com",
+							"firstName": "Oran",
+							"lastName": "Schroeder"
+						},
+						{
+							"id": "65de346a255f31cb84bd0e01",
+							"email": "Katheryn82@hotmail.com",
+							"firstName": "Katheryn",
+							"lastName": "Hammes"
+						},],
+						getContracts: async () => [
+							{
+								id: 5,
+								developerId: '65de346a255f31cb84bd0e01',
+								status: 'completed',
+								amount: 6000
+							},
+							{
+								id: 6,
+								developerId: '65de346a255f31cb84bd0e01',
+								status: 'completed',
+								amount: 5000
+							},
+						],
+					} as Partial<DevelopersRepository>
+				}
+			})
+		})
+
+		it('should include revenue when include=revenue is specified', async () => {
+			const result = await req.get(`/api/developers/?include=revenue`)
+
+			expect(result.status).toBe(200)
+			expect(Array.isArray(result.body)).toBe(true)
+
+			const developers = result.body
+			const byId = (id: string) => developers.find((d: any) => d.id === id)
+
+			const dev1 = byId('65de346a255f31cb84bd0e01')
+			expect(dev1).toBeTruthy()
+			expect(dev1).toHaveProperty('revenue', 11000)
+
+			const dev2 = byId('65de346c255f31cb84bd105c')
+			expect(dev2).toBeTruthy()
+			expect(dev2).toHaveProperty('revenue', 0)
+		})
+
+		it('should ignore unknown include values and not include revenue', async () => {
+			const result = await req.get(`/api/developers?include=something_else`)
+
+			expect(result.status).toBe(200)
+			for (const developer of result.body) {
+				expect(developer).not.toHaveProperty('revenue')
+			}
+		})
+	})
 })


### PR DESCRIPTION
In this PR I Implemented support for returning developer revenue in the Developers API.
The revenue is calculated as the sum of all completed contracts for each developer and is now available as an additional field in the API response.

Details

1. Extended the Developers API to optionally include revenue for each developer.
2. Ensured backward compatibility so existing consumers of the API (e.g., contracts dashboard, developers management dashboard) continue to work without changes.
3. Optimized query to aggregate contract amounts only for completed contracts.
4. Added tests to cover both cases: developers with and without revenue.